### PR TITLE
Fix dragon to lizan

### DIFF
--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -770,7 +770,7 @@ use namespace kGAMECLASS;
 			{
 				race = "lizan";
 			}
-			if (dragonScore() >= 6)
+			if (dragonScore() > 6)
 			{
 				race = "dragon-morph";
 				if (faceType == 0)

--- a/classes/classes/Player.as
+++ b/classes/classes/Player.as
@@ -769,6 +769,8 @@ use namespace kGAMECLASS;
 			if (lizardScore() >= 4)
 			{
 				race = "lizan";
+				if (isTaur())
+					race += "-taur";
 			}
 			if (dragonScore() > 6)
 			{
@@ -1372,7 +1374,7 @@ use namespace kGAMECLASS;
 				dragonCounter++;
 			if (skinType == 2 && dragonCounter > 0)
 				dragonCounter++;
-			if (hornType == HORNS_DRACONIC_X4_12_INCH_LONG || hornType == HORNS_DRACONIC_X2)
+			if (hornType == HORNS_DRACONIC_X4_12_INCH_LONG)
 				dragonCounter++;
 			if (findPerk(PerkLib.Dragonfire) >= 0)
 				dragonCounter++;


### PR DESCRIPTION
## Important: This is based on PR #256!

**Fixed ' Appearance-tab still displays dragon-morph, when going from all-dragon-tfs to all-lizan':**
The fix is incomplete.
It must read `if (dragonScore() > 6)`
not `if (dragonScore() >= 6)`

**Small horns tweak for dragonScore() + lizan-taur:**
I've tweaked player.dragonScore() a little. Now you get one point added
for two horns and another one for 4 horns.
Additionally I've included the lizan-taur. Mainly to locally test this
PR. Looks fine now (hopefully)
